### PR TITLE
Allow counting of records to work for series as well as dataframes

### DIFF
--- a/macroecotools/macroecotools.py
+++ b/macroecotools/macroecotools.py
@@ -358,8 +358,8 @@ def abundance_in_group(composition_data, group_cols, abund_col=None):
     if abund_col:
         abundance = composition_data[group_cols + abund_col].groupby(group_cols).sum()
     else:
-        abundance = composition_data[group_cols].groupby(group_cols).count()
-    abundance = pandas.DataFrame(abundance.iloc[:, 0]) # Get a single count regardless of # of grouping variables
+        abundance = composition_data[group_cols].groupby(group_cols).size()
+    abundance = pandas.DataFrame(abundance)
     abundance.columns = ['abundance']
     abundance = abundance.reset_index()
     return abundance


### PR DESCRIPTION
abundance_in_group was failing when the lack of an abundance
column resulted in trying to use .count() on a Series instead of
a Dataframe. This replaces that call with .size() which works on
both.

It also removes an unnecessary slicing to remove columns that
should never exist.

Fixes #10.
