### PR TITLE
improve numerical precision of negbin loglik

### DIFF
--- a/macroeco_distributions/macroeco_distributions.py
+++ b/macroeco_distributions/macroeco_distributions.py
@@ -445,7 +445,7 @@ def trunc_geom_ll(ab, p, upper_bound):
 
 def negbin_ll(ab, n, p):
     """Log-likelihood of a negative binomial dstribution (truncated at 1)"""
-    return sum(stats.nbinom.logpmf(ab, n, p)) - len(ab) * log(1 - stats.nbinom.pmf(0, n, p))
+    return sum(stats.nbinom.logpmf(ab, n, p)) - len(ab) * stats.nbinom.logsf(0, n, p)
 
 def dis_gamma_ll(ab, k, theta):
     """Log-likelihood of a discrete gamma distribution


### PR DESCRIPTION
Per my comments in https://github.com/weecology/sad-comparison/issues/93

If I did things correctly (and didn't just re-run the unit tests for the master branch), this should give the same answer when things are numerically stable. The fact that we're not calculating `log(1-p)` manually anymore should improve the precision when most of the probability mass is at zero.