### PR TITLE
rescale negbin optimization

### DIFF
--- a/macroeco_distributions/macroeco_distributions.py
+++ b/macroeco_distributions/macroeco_distributions.py
@@ -35,6 +35,7 @@ import numpy as np
 from scipy import integrate, stats, optimize, special
 from scipy.stats import rv_discrete, rv_continuous, itemfreq
 from scipy.optimize import bisect, fsolve
+from scipy.special import logit, expit
 from scipy.integrate import quad
 
 #._rvs method is not currently available for pln.
@@ -543,11 +544,12 @@ def negbin_solver(ab):
     mu = np.mean(ab)
     var = np.var(ab, ddof = 1)
     p0 = 1 - mu / var
-    n0 = mu * (1 - p0) / p0
-    def negbin_func(x): 
-        return -negbin_ll(ab, x[0], x[1])
-    n, p = optimize.fmin(negbin_func, x0 = [n0, p0])
-    return n, p
+    logit_p0 = logit(p0)
+    log_n0 = log(mu * (1 - p0) / p0)
+    def negbin_func(x):
+        return -negbin_ll(ab, exp(x[0]), expit(x[1]))
+    log_n, logit_p = optimize.fmin(negbin_func, x0 = [log_n0, logit_p0])
+    return exp(log_n), expit(logit_p)
 
 def dis_gamma_solver(ab):
     """Given abundance data, solve for MLE of discrete gamma parameters k and theta"""


### PR DESCRIPTION
This changes the scale that the optimizer works on for negbin.  In this version, `n` is adjusted on the log scale and `p` is adjusted on the logit scale. Both values are transformed back to the natural scale before being fed to negbin_ll.

On the transformed scales, `fmin` can move around more easily without approaching arbitrarily steep likelihoods near 0 or 1.  In my tests the abundance vector produced below, this improves the log-likelihood of the MLE by 12. This should increase the weight by a factor of 160,000.

```
ab = [1, 5, 81, 55, 71, 24, 60, 14, 19, 9, 14, 31, 19, 40, 12, 2,
6, 78, 78, 2, 6, 5, 135, 76, 5, 108, 1, 67, 6, 1, 1, 79, 154,
3, 50, 23, 2656, 5, 26, 9, 101, 10, 1, 1, 208, 1, 58, 2, 1, 2,
61, 187, 24, 9, 78, 2, 229, 22, 106, 91, 125, 1500635, 49, 33,
1001435, 81, 3, 8, 9, 66, 50]
```

Before: -426.97404961

After: -414.906939357

Improvement: 12.06711