### PR TITLE
Bug fix in trunc_geom_solver()

### DIFF
--- a/macroeco_distributions/macroeco_distributions.py
+++ b/macroeco_distributions/macroeco_distributions.py
@@ -516,7 +516,7 @@ def trunc_geom_solver(ab, upper_bound):
     DIST_FROM_BOUND = 10 ** -10
     S = len(ab)
     N = sum(ab)
-    y = lambda x: (S * upper_bound * (1 - x) + S - N * (1 - x)) * x ** upper_bound - S + N * (1 - x)
+    y = lambda x: ((S * upper_bound - N) * (1 - x) + S) * x ** upper_bound - S + N * (1 - x)
     one_minus_p = optimize.bisect(y, 1 - S/N - DIST_FROM_BOUND, BOUNDS[1] - DIST_FROM_BOUND, 
                                   xtol = 1.490116e-16)
     return 1 - one_minus_p

--- a/macroeco_distributions/macroeco_distributions.py
+++ b/macroeco_distributions/macroeco_distributions.py
@@ -516,7 +516,7 @@ def trunc_geom_solver(ab, upper_bound):
     DIST_FROM_BOUND = 10 ** -10
     S = len(ab)
     N = sum(ab)
-    y = lambda x: (N * (S-1) * (1-x) + S) * x ** upper_bound + N * (1-x) - S
+    y = lambda x: (S * upper_bound * (1 - x) + S - N * (1 - x)) * x ** upper_bound - S + N * (1 - x)
     one_minus_p = optimize.bisect(y, 1 - S/N - DIST_FROM_BOUND, BOUNDS[1] - DIST_FROM_BOUND, 
                                   xtol = 1.490116e-16)
     return 1 - one_minus_p


### PR DESCRIPTION
While working on @davharris 's suggestion on rewriting some of these solver functions for stability, I found a bug in `trunc_geom_solver()`. Basically the old code would only yield the correct answer when `upper_bound = sum(ab)`, which I think is what we've been doing so thankfully it will not affect our results. 

I'm becoming less and less confident about my algebra though. If folks could give the new equation a check, that would be great.